### PR TITLE
fix: enforce minimum required command length in CrosECIoctlXCmd.

### DIFF
--- a/CrosEC/Queue.c
+++ b/CrosEC/Queue.c
@@ -69,7 +69,7 @@ NTSTATUS CrosECQueueInitialize(_In_ WDFDEVICE Device) {
 NTSTATUS CrosECIoctlXCmd(_In_ WDFDEVICE Device, _In_ PDEVICE_CONTEXT DeviceContext, _In_ WDFREQUEST Request) {
 	PCROSEC_COMMAND cmd;
 	size_t cmdLen;
-	NT_RETURN_IF_NTSTATUS_FAILED(WdfRequestRetrieveInputBuffer(Request, sizeof(cmd), (PVOID*)&cmd, &cmdLen));
+	NT_RETURN_IF_NTSTATUS_FAILED(WdfRequestRetrieveInputBuffer(Request, sizeof(*cmd), (PVOID*)&cmd, &cmdLen));
 
 	void* outbuf;
 	size_t outLen;


### PR DESCRIPTION
Let me preface this PR by saying that I am neither a C dev nor a Windows driver dev. However, while I was reading the driver source code for learning purposes, I believed to have spotted an issue.

---

There seems to be a subtle bug when it comes to validating the minimum required driver command length in `CrosECIoctlXCmd`. Instead of the minimum required command length being the size of the struct `sizeof(CROSEC_COMMAND)`, the size of the **pointer** to the struct `sizeof(PCROSEC_COMMAND)` was being used.

For this to have a real world impact, the userland code would have to send a command to the driver whose input buffer is too small. Then `CrosECIoctlXCmd` would read past the input buffer.